### PR TITLE
Add Unit Tests for `window-observer` Components

### DIFF
--- a/server/observers/window-observer/lib/lib_common_test.go
+++ b/server/observers/window-observer/lib/lib_common_test.go
@@ -1,0 +1,46 @@
+// lib_common_test.go
+package lib
+
+import "testing"
+
+func ptr(s string) *string { return &s }
+
+func TestStringPtr(t *testing.T) {
+	tests := []struct {
+		in   string
+		want *string
+	}{
+		{"", nil},
+		{"hello", ptr("hello")},
+	}
+	for _, tt := range tests {
+		got := StringPtr(tt.in)
+		if tt.want == nil {
+			if got != nil {
+				t.Errorf("StringPtr(%q) = %v; want nil", tt.in, got)
+			}
+		} else {
+			if got == nil || *got != *tt.want {
+				t.Errorf("StringPtr(%q) = %v; want %v", tt.in, got, tt.want)
+			}
+		}
+	}
+}
+
+func TestBoolPtr(t *testing.T) {
+	b1 := boolPtr(true)
+	if b1 == nil || *b1 != true {
+		t.Errorf("boolPtr(true) = %v; want pointer to true", b1)
+	}
+	b2 := boolPtr(false)
+	if b2 == nil || *b2 != false {
+		t.Errorf("boolPtr(false) = %v; want pointer to false", b2)
+	}
+}
+
+func TestFatalError_Error(t *testing.T) {
+	err := FatalError{"something went wrong"}
+	if err.Error() != "something went wrong" {
+		t.Errorf("FatalError.Error() = %q; want %q", err.Error(), "something went wrong")
+	}
+}

--- a/server/observers/window-observer/lib/lib_darwin_test.go
+++ b/server/observers/window-observer/lib/lib_darwin_test.go
@@ -1,0 +1,22 @@
+//go:build darwin
+// +build darwin
+
+package lib
+
+import "testing"
+
+func TestGetCurrentWindowMacOS_InvalidStrategy(t *testing.T) {
+	_, err := GetCurrentWindowMacOS("not-a-strategy")
+	fe, ok := err.(FatalError)
+	if !ok {
+		t.Fatalf("expected FatalError, got %T", err)
+	}
+	want := `invalid strategy "not-a-strategy"`
+	if fe.Error() != want {
+		t.Errorf("Error() = %q; want %q", fe.Error(), want)
+	}
+}
+
+func TestGetCurrentWindowMacOS_JXA_and_AppleScript(t *testing.T) {
+	t.Skip("needs mocking of GetInfo and GetInfoAppleScript")
+}

--- a/server/observers/window-observer/lib/lib_linux_test.go
+++ b/server/observers/window-observer/lib/lib_linux_test.go
@@ -1,0 +1,14 @@
+//go:build linux
+// +build linux
+
+package lib
+
+import "testing"
+
+func TestGetCurrentWindowLinux_NoXServer(t *testing.T) {
+	t.Skip("requires a running X server or mocked xgbutil.NewConn")
+}
+
+func TestGetCurrentWindowLinux_BasicFallback(t *testing.T) {
+	t.Skip("fill in once you can stub GetCurrentWindowID, GetWindowClass, GetWindowName")
+}

--- a/server/observers/window-observer/lib/lib_windows_test.go
+++ b/server/observers/window-observer/lib/lib_windows_test.go
@@ -1,0 +1,10 @@
+//go:build windows
+// +build windows
+
+package lib
+
+import "testing"
+
+func TestGetCurrentWindowWindows(t *testing.T) {
+	t.Skip("requires Windows environment or stubs for GetActiveWindowHandle, GetAppName, GetWindowTitle")
+}

--- a/server/observers/window-observer/main/main.go
+++ b/server/observers/window-observer/main/main.go
@@ -27,6 +27,8 @@ import (
 	"github.com/joho/godotenv"
 )
 
+var getCurrentWindow = lib.GetCurrentWindow
+
 func main() {
 	_ = godotenv.Load()
 
@@ -115,8 +117,17 @@ func main() {
 	}
 }
 
-func handleHeartBeat(tg *client.TimelyGatorClient, bucket string, strategy string, exclTitle bool, patterns []*regexp.Regexp, poll time.Duration) {
-	win, err := lib.GetCurrentWindow(strategy)
+type heartbeatSender interface {
+    Heartbeat(bucket string,
+              data interface{},
+              pulse float64,
+              wait bool,
+              extra *float64,
+    ) error
+}
+
+func handleHeartBeat(tg heartbeatSender, bucket string, strategy string, exclTitle bool, patterns []*regexp.Regexp, poll time.Duration) {
+	win, err := getCurrentWindow(strategy)
 	if err != nil {
 		log.Printf("getCurrentWindow error: %v", err)
 		return

--- a/server/observers/window-observer/main/main_test.go
+++ b/server/observers/window-observer/main/main_test.go
@@ -1,0 +1,128 @@
+//go:build linux || darwin || windows
+// +build linux darwin windows
+
+package main
+
+import (
+    "encoding/json"
+    "regexp"
+    "testing"
+    "time"
+
+    "timelygator/server/database/models"
+    "timelygator/server/observers/window-observer/lib"
+)
+
+// --- fake heartbeatSender ---
+type fakeTG struct {
+    bucket string
+    data   interface{}
+    pulse  float64
+    called bool
+}
+
+func (f *fakeTG) Heartbeat(bucket string, data interface{}, pulse float64, wait bool, extra *float64) error {
+    f.bucket = bucket
+    f.data = data
+    f.pulse = pulse
+    f.called = true
+    return nil
+}
+
+// stub getCurrentWindow
+func mockWin(app, title string, url *string, inc *bool) func(string) (*lib.WindowInfo, error) {
+    return func(_ string) (*lib.WindowInfo, error) {
+        return &lib.WindowInfo{App: app, Title: title, URL: url, Incognito: inc}, nil
+    }
+}
+
+func TestHandleHeartBeat_Basic(t *testing.T) {
+    url := "https://foo"
+    inc := true
+
+    // override getCurrentWindow
+    oldGW := getCurrentWindow
+    getCurrentWindow = mockWin("MyApp", "MyTitle", &url, &inc)
+    defer func() { getCurrentWindow = oldGW }()
+
+    ft := &fakeTG{}
+    poll := 3 * time.Second
+
+    handleHeartBeat(ft, "buck", "any", false, nil, poll)
+
+    if !ft.called {
+        t.Fatal("expected Heartbeat to be called")
+    }
+    if ft.bucket != "buck" {
+        t.Errorf("bucket = %q; want %q", ft.bucket, "buck")
+    }
+
+    // we know we passed a *models.Event in data
+    ev, ok := ft.data.(*models.Event)
+    if !ok {
+        t.Fatalf("expected data to be *models.Event, got %T", ft.data)
+    }
+    var payload map[string]interface{}
+    if err := json.Unmarshal(ev.Data, &payload); err != nil {
+        t.Fatalf("unmarshal event.Data: %v", err)
+    }
+    if payload["app"] != "MyApp" || payload["title"] != "MyTitle" {
+        t.Errorf("payload = %+v; want app=MyApp,title=MyTitle", payload)
+    }
+
+    wantPulse := poll.Seconds() + 1
+    if ft.pulse != wantPulse {
+        t.Errorf("pulse = %v; want %v", ft.pulse, wantPulse)
+    }
+}
+
+func TestHandleHeartBeat_RegexAnonymize(t *testing.T) {
+    oldGW := getCurrentWindow
+    getCurrentWindow = mockWin("X", "Secret", nil, nil)
+    defer func() { getCurrentWindow = oldGW }()
+
+    ft := &fakeTG{}
+    patterns := []*regexp.Regexp{regexp.MustCompile("(?i)secret")}
+    handleHeartBeat(ft, "b", "any", false, patterns, time.Second)
+
+    ev := ft.data.(*models.Event)
+    var payload map[string]interface{}
+    _ = json.Unmarshal(ev.Data, &payload)
+    if payload["title"] != "excluded" {
+        t.Errorf("title = %v; want excluded", payload["title"])
+    }
+}
+
+func TestHandleHeartBeat_ForceExclude(t *testing.T) {
+    oldGW := getCurrentWindow
+    getCurrentWindow = mockWin("X", "Whatever", nil, nil)
+    defer func() { getCurrentWindow = oldGW }()
+
+    ft := &fakeTG{}
+    handleHeartBeat(ft, "b", "any", true, nil, time.Second)
+
+    ev := ft.data.(*models.Event)
+    var payload map[string]interface{}
+    _ = json.Unmarshal(ev.Data, &payload)
+    if payload["title"] != "excluded" {
+        t.Errorf("title = %v; want excluded", payload["title"])
+    }
+}
+
+func TestInterrupt(t *testing.T) {
+    ch := interrupt()
+    if ch == nil {
+        t.Fatal("interrupt returned nil")
+    }
+}
+
+func TestHostPortPtr(t *testing.T) {
+    s := "hello"
+    if got := hostPtr(&s); got != "hello" {
+        t.Errorf("hostPtr = %q; want hello", got)
+    }
+    i := 42
+    if got := portPtr(&i); got != "42" {
+        t.Errorf("portPtr = %q; want 42", got)
+    }
+}


### PR DESCRIPTION
Adds tests for core components of the `window-observer` package including `lib_common.go`, `main.go`, and test scaffolds for platform-specific implementations.

### **Changes Made**

#### `lib_common_test.go`
- Unit tests for:
  - `StringPtr`
  - `boolPtr`
  - `FatalError.Error`

#### `main_test.go`
- Added unit tests for:
  - `handleHeartBeat`:
    - Basic event generation
    - Title exclusion via flag
    - Title anonymization via regex
  - `interrupt` function
  - Helper functions `hostPtr`, `portPtr`
- Introduced:
  - **interface** `heartbeatSender` to allow mocking `client.TimelyGatorClient`
  - `getCurrentWindow` variable to stub `lib.GetCurrentWindow` in tests

#### Test stubs for platform-specific logic
- `lib_linux_test.go`  
- `lib_darwin_test.go`  
- `lib_windows_test.go`

Each stub uses `t.Skip(...)` to allow future expansion when mocks or OS-specific environments are available.


### Refactoring

- Modified `handleHeartBeat()` to use an interface (`heartbeatSender`) instead of concrete `*TimelyGatorClient`
- Replaced direct call to `lib.GetCurrentWindow` with `getCurrentWindow` to allow test injection

### How to Run Tests

```bash
cd server/observers/window-observer

# Run shared logic tests
go test ./lib -v

# Run main logic
go test ./main -v

# Platform-specific logic (only on matching OS)
go test -tags=linux ./lib
go test -tags=darwin ./lib
go test -tags=windows ./lib
```